### PR TITLE
Enhancement/convert asciidoc

### DIFF
--- a/engine/converter.ts
+++ b/engine/converter.ts
@@ -56,7 +56,7 @@ private platform: ConsolePlatform;
          * 1. Write asciidocString to temp.adoc file
          * 2. Use AsciiDoctor to convert AsciiDoc String to DocBook XML file
          * 3. Use Pandoc to convert DocBook XML file to Markdown File
-         * 4. Read Markdown file (eventually combine with step 2)
+         * 4. Read Markdown file (eventually combine with step 2?)
          */
 
         this.createTempFile("temp.adoc", asciidocString);
@@ -67,7 +67,9 @@ private platform: ConsolePlatform;
             this.executeCommand("pandoc -f docbook -t markdown temp.xml -o temp.md", this.getTempDir());
             markdownString = this.readTempFile("temp.md");
         }else {
-            
+            this.executeCommand("asciidoctor -b docbook temp.adoc", this.getTempDir());
+            this.executeCommand("pandoc -f docbook -t markdown temp.xml -o temp.md", this.getTempDir());
+            markdownString = this.readTempFile("temp.md");
         }
         return markdownString;
     }

--- a/engine/converter.ts
+++ b/engine/converter.ts
@@ -52,26 +52,28 @@ private platform: ConsolePlatform;
     }
 
     convertAsciidocToMarkdown(asciidocString: string): string {
-        /**
-         * 1. Write asciidocString to temp.adoc file
-         * 2. Use AsciiDoctor to convert AsciiDoc String to DocBook XML file
-         * 3. Use Pandoc to convert DocBook XML file to Markdown File
-         * 4. Read Markdown file (eventually combine with step 2?)
-         */
+        if(asciidocString !== undefined) {
+            /**
+             * 1. Write asciidocString to temp.adoc file
+             * 2. Use AsciiDoctor to convert AsciiDoc String to DocBook XML file
+             * 3. Use Pandoc to convert DocBook XML file to Markdown File
+             * 4. Read Markdown file (eventually combine with step 2?)
+             */
 
-        this.createTempFile("temp.adoc", asciidocString);
+            this.createTempFile("temp.adoc", asciidocString);
 
-        let markdownString = "";
-        if(this.platform == ConsolePlatform.WINDOWS) {
-            this.executeCommand("asciidoctor -b docbook temp.adoc", this.getTempDir());
-            this.executeCommand("pandoc -f docbook -t markdown temp.xml -o temp.md", this.getTempDir());
-            markdownString = this.readTempFile("temp.md");
-        }else {
-            this.executeCommand("asciidoctor -b docbook temp.adoc", this.getTempDir());
-            this.executeCommand("pandoc -f docbook -t markdown temp.xml -o temp.md", this.getTempDir());
-            markdownString = this.readTempFile("temp.md");
-        }
-        return markdownString;
+            let markdownString = "";
+            if(this.platform == ConsolePlatform.WINDOWS) {
+                this.executeCommand("asciidoctor -b docbook temp.adoc", this.getTempDir());
+                this.executeCommand("pandoc -f docbook -t gfm temp.xml -o temp.md", this.getTempDir());
+                markdownString = this.readTempFile("temp.md");
+            }else {
+                this.executeCommand("asciidoctor -b docbook temp.adoc", this.getTempDir());
+                this.executeCommand("pandoc -f docbook -t markdown temp.xml -o temp.md", this.getTempDir());
+                markdownString = this.readTempFile("temp.md");
+            }    
+            return markdownString;
+        }        
     }
 
     executeCommand(command: string, directory: string) {

--- a/engine/converter.ts
+++ b/engine/converter.ts
@@ -1,0 +1,82 @@
+import { ConsolePlatform } from "../runners/console/consoleInterfaces";
+import { ConsoleUtils } from "../runners/console/consoleUtils";
+import * as child_process from "child_process"
+import * as path from "path"
+import * as fs from "fs"
+import { pathToFileURL } from "url";
+import { fstat } from "fs";
+import { FileContains } from "../assertions/fileContains";
+
+export class Converter {
+
+private readonly TMP_DIR = "tmp_convert";
+
+private platform: ConsolePlatform;
+
+    constructor() {
+        // Determine platform for script execution
+        if(process.platform == "win32") {
+            this.platform = ConsolePlatform.WINDOWS;
+        }else {
+            this.platform = ConsolePlatform.LINUX;
+        }
+
+        // Create temporary directory in which files can be created & modified
+        this.createTempDir();
+    }
+
+    createTempDir(): void {
+        // Create tempDir if not already existing
+        let dir = this.getTempDir();
+        if(!fs.existsSync(dir)) {
+            fs.mkdirSync(dir);
+        }
+    }
+
+
+    createTempFile(filename: string, content: string) {
+        fs.writeFileSync(path.join(this.getTempDir(),filename), content);
+    }
+
+    readTempFile(filename: string): string {
+        let file_path = path.join(this.getTempDir(), filename);
+        let fileContent = "";
+        let file = fs.readFileSync(file_path);
+        fileContent = file.toString()
+        return fileContent;
+    }
+
+    getTempDir(): string {
+        // Return tempDir
+        return path.join(__dirname, this.TMP_DIR);
+    }
+
+    convertAsciidocToMarkdown(asciidocString: string): string {
+        /**
+         * 1. Write asciidocString to temp.adoc file
+         * 2. Use AsciiDoctor to convert AsciiDoc String to DocBook XML file
+         * 3. Use Pandoc to convert DocBook XML file to Markdown File
+         * 4. Read Markdown file (eventually combine with step 2)
+         */
+
+        this.createTempFile("temp.adoc", asciidocString);
+
+        let markdownString = "";
+        if(this.platform == ConsolePlatform.WINDOWS) {
+            this.executeCommand("asciidoctor -b docbook temp.adoc", this.getTempDir());
+            this.executeCommand("pandoc -f docbook -t markdown temp.xml -o temp.md", this.getTempDir());
+            markdownString = this.readTempFile("temp.md");
+        }else {
+            
+        }
+        return markdownString;
+    }
+
+    executeCommand(command: string, directory: string) {
+        let process = child_process.spawnSync(command, {shell: true, cwd: directory});
+        if(process.status != 0) {
+            console.log("Error executing command: " + command + " (exit code: )" + process.status + ")");
+            console.log(process.stderr.toString(), process.stdout.toString());
+        }
+    }
+}

--- a/runners/katacoda/index.ts
+++ b/runners/katacoda/index.ts
@@ -65,8 +65,8 @@ export class Katacoda extends Runner {
 
     async destroy(playbook: Playbook): Promise<void> {
         let tutorialDirectoryName = path.basename(playbook.path);
-        this.renderTemplate("intro.md", path.join(this.outputPathTutorial, "intro.md"), { description: playbook.description, tutorialPath: tutorialDirectoryName });
-        fs.writeFileSync(this.outputPathTutorial + 'finish.md', playbook.conclusion);
+        this.renderTemplate("intro.md", path.join(this.outputPathTutorial, "intro.md"), { description: this.converter.convertAsciidocToMarkdown(playbook.description), tutorialPath: tutorialDirectoryName });
+        fs.writeFileSync(this.outputPathTutorial + 'finish.md', this.converter.convertAsciidocToMarkdown(playbook.conclusion));
 
         // create and configure required files for the setup process
         this.renderTemplate(path.join("scripts", "intro_foreground.sh"), path.join(this.outputPathTutorial, "intro_foreground.sh"), { });

--- a/runners/katacoda/index.ts
+++ b/runners/katacoda/index.ts
@@ -9,6 +9,7 @@ import { DirUtils } from "./dirUtils";
 import * as path from 'path';
 import * as ejs from 'ejs';
 import * as fs from 'fs';
+import { Converter } from "../../engine/converter";
 
 export class Katacoda extends Runner {
 
@@ -24,6 +25,7 @@ export class Katacoda extends Runner {
     private terminalCounter: number = 1;
     private showVsCodeIde: boolean = false;
     private terminals: KatacodaTerminals[] = [{function: "default", terminalId: 1}];
+    private converter: Converter;
  
     init(playbook: Playbook): void {
         // create directory for katacoda tutorials if not exist
@@ -47,6 +49,8 @@ export class Katacoda extends Runner {
 
         //set working direktory
         this.setVariable(this.WORKSPACE_DIRECTORY, path.join("/root"));
+
+        this.converter = new Converter();
 
         this.assetManager = new KatacodaAssetManager(path.join(this.outputPathTutorial, "assets"));
         
@@ -463,6 +467,13 @@ export class Katacoda extends Runner {
     }
 
     private renderTemplate(name: string, targetPath: string, variables) {
+        if("text" in variables) {
+            variables["text"] = this.converter.convertAsciidocToMarkdown(variables["text"]);
+        }
+        if("textAfter" in variables) {
+            variables["textAfter"] = this.converter.convertAsciidocToMarkdown(variables["textAfter"]);
+        }
+        
         let template = fs.readFileSync(path.join(this.getRunnerDirectory(),"templates", name), 'utf8');
         let result = ejs.render(template, variables);
         fs.writeFileSync(targetPath, result, {flag: "a"});


### PR DESCRIPTION
This PR includes changes that convert AsciiDoc syntax into Markdown syntax at these locations: 

- "text" and "textAfter' placeholders in [renderTemplate](https://github.com/derochs/tutorial-compiler/blob/enhancement/convertAsciidoc/runners/katacoda/index.ts#L470) will be converted into Markdown, as they may contain AsciiDoc syntax
- in the [destroy function](https://github.com/derochs/tutorial-compiler/blob/enhancement/convertAsciidoc/runners/katacoda/index.ts#L66), the playbook description will be converted into Markdown, as well as the playbook conclusion

**Note: If this PR is merged, you'll have to install Pandoc and Asciidoctor on your local machine**

**Linux**: 
- Pandoc: `sudo wget https://github.com/jgm/pandoc/releases/download/2.14.0.2/pandoc-2.14.0.2-1-amd64.deb && sudo dpkg -i pandoc-2.14.0.2-1-amd64.deb`
- Asciidoctor: `sudo apt install asciidoctor`

**Windows**: 
- Pandoc:
  - First install chocolatey with PowerShell: `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
  - Then install pandoc: `choco install pandoc`
- Asciidoctor: 
  - First install Ruby: `choco install ruby`
  - Then install Asciidoctor: `gem install asciidoctor`