### PR TITLE
updated npm package version and workflows

### DIFF
--- a/.github/workflows/linuxMain.yml
+++ b/.github/workflows/linuxMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '15'
+          node-version: '16'
         
       - name: install Pandoc
         run: sudo apt install pandoc

--- a/.github/workflows/linuxMain.yml
+++ b/.github/workflows/linuxMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '16'
+          node-version: '15'
         
       - name: install Pandoc
         run: sudo apt install pandoc

--- a/.github/workflows/linuxMain.yml
+++ b/.github/workflows/linuxMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
         
       - name: install Pandoc
         run: sudo apt install pandoc
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt install asciidoctor
 
       - name: install TS
-        run: npm install typescript
+        run: npm install -g typescript
       
       - name: npm install
         run: npm install

--- a/.github/workflows/linuxMain.yml
+++ b/.github/workflows/linuxMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '16'
+          node-version: '14'
         
       - name: install Pandoc
         run: sudo apt install pandoc

--- a/.github/workflows/linuxPullRequest.yml
+++ b/.github/workflows/linuxPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '16'
+          node-version: '15'
         
       - name: install Pandoc
         run: sudo apt install pandoc

--- a/.github/workflows/linuxPullRequest.yml
+++ b/.github/workflows/linuxPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
         
       - name: install Pandoc
         run: sudo apt install pandoc
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt install asciidoctor
         
       - name: install TS
-        run: npm install typescript
+        run: npm install -g typescript
       
       - name: npm install
         run: npm install

--- a/.github/workflows/linuxPullRequest.yml
+++ b/.github/workflows/linuxPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '15'
+          node-version: '16'
         
       - name: install Pandoc
         run: sudo apt install pandoc

--- a/.github/workflows/linuxPullRequest.yml
+++ b/.github/workflows/linuxPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '16'
+          node-version: '14'
         
       - name: install Pandoc
         run: sudo apt install pandoc

--- a/.github/workflows/windowsMain.yml
+++ b/.github/workflows/windowsMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '16'
+          node-version: '15'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/windowsMain.yml
+++ b/.github/workflows/windowsMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '15'
+          node-version: '14'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/windowsMain.yml
+++ b/.github/workflows/windowsMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/windowsMain.yml
+++ b/.github/workflows/windowsMain.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1
@@ -34,7 +34,7 @@ jobs:
         run: gem install asciidoctor
         
       - name: install TS
-        run: npm install typescript
+        run: npm install -g typescript
       
       - name: npm install
         run: npm install

--- a/.github/workflows/windowsPullRequest.yml
+++ b/.github/workflows/windowsPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '16'
+          node-version: '15'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/windowsPullRequest.yml
+++ b/.github/workflows/windowsPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1

--- a/.github/workflows/windowsPullRequest.yml
+++ b/.github/workflows/windowsPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14'
+          node-version: '16'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1
@@ -27,7 +27,7 @@ jobs:
         run: gem install asciidoctor
         
       - name: install TS
-        run: npm install typescript
+        run: npm install -g typescript
       
       - name: npm install
         run: npm install

--- a/.github/workflows/windowsPullRequest.yml
+++ b/.github/workflows/windowsPullRequest.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '15'
+          node-version: '14'
         
       - name: install Pandoc
         uses: crazy-max/ghaction-chocolatey@v1

--- a/package.json
+++ b/package.json
@@ -4,25 +4,25 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@types/chai": "^4.2.14",
-    "@types/mocha": "^8.2.0",
-    "@types/node": "^14.14.2",
-    "chai": "^4.2.0",
-    "ejs": "^3.1.5",
-    "find-process": "^1.4.4",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^8.2.3",
+    "@types/node": "^16.11.7",
+    "chai": "^4.3.6",
+    "ejs": "^3.1.6",
+    "find-process": "^1.4.7",
     "fs-extra": "^9.1.0",
-    "is-reachable": "^5.0.0",
-    "mocha": "^8.2.1",
+    "is-reachable": "^5.1.1",
+    "mocha": "^8.4.0",
     "pegjs": "^0.10.0",
     "process-list": "^2.0.0",
     "rimraf": "^3.0.2",
     "ts-pegjs": "^0.2.7",
     "vscode-extension-tester": "^3.2.5",
-    "yargs": "^16.1.0"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@types/jasmine": "^3.6.2",
-    "jasmine": "^3.6.2"
+    "@types/jasmine": "^3.10.3",
+    "jasmine": "^3.99.0"
   },
   "scripts": {
     "test": "npx jasmine"


### PR DESCRIPTION
Changed the node versions in the Workflow.
There are some problems with `npm install` for
- Linux on node ver. 16
- Windows on node ver. 14

This is only a short time solution to get the workflows running again and is not considert as a problem solution.
Watch the Issues 
- [Windows build fails while executing npm install](https://github.com/devonfw-tutorials/tutorial-compiler/issues/342)
- [Node version 16 breaks GitHub workflows](https://github.com/devonfw-tutorials/tutorial-compiler/issues/338)
